### PR TITLE
Fixed Help Button Image Reference

### DIFF
--- a/Snippets/Help Button/README.md
+++ b/Snippets/Help Button/README.md
@@ -1,5 +1,5 @@
 # Help Button
-![Help Button](Help Button.jpg)
+![Help Button](Help%20Button.jpg)
 A floating help button in the bottom right corner.
 
 ## How to Install Help Button


### PR DESCRIPTION
Added URL encoding to `Help Button.jpg` image reference so it will render directly on GitHub when viewing the page.